### PR TITLE
Fix docs for config.toml

### DIFF
--- a/.cursor/rules/agent-architecture.mdc
+++ b/.cursor/rules/agent-architecture.mdc
@@ -95,7 +95,7 @@ The [prompt_templates](mdc:src/agents/prompt_templates) directory contains a mod
 ### ⚠️ Important Note: Streaming Functionality Not Recommended
 - Current streaming implementation has known issues and stability concerns
 - **Developers and users are advised not to enable streaming mode** until future optimizations
-- Set `enable_streaming` parameter to `false` in `config.yaml` for both agent types
+- Set `enable_streaming` parameter to `false` in `config.toml` for both agent types
 
 ### Streaming Components
 

--- a/.cursor/rules/configuration.mdc
+++ b/.cursor/rules/configuration.mdc
@@ -9,7 +9,7 @@ DeepSearchAgent uses a flexible configuration system with multiple options for c
 
 ## Configuration Sources
 
-1. **@config.yaml** configuration file
+1. **@config.toml** configuration file
 2. **Environment Variables**: Override config file settings
 3. **Command Line Arguments**: Highest precedence overrides
 

--- a/.cursor/rules/periodic-planning.mdc
+++ b/.cursor/rules/periodic-planning.mdc
@@ -50,7 +50,7 @@ The CodeAct planning involves:
 
 Planning intervals can be configured in:
 
-1. [config.yaml](mdc:config.yaml):
+1. [config.toml](mdc:config.toml):
    ```yaml
    agents:
      react:

--- a/.cursor/rules/project-overview.mdc
+++ b/.cursor/rules/project-overview.mdc
@@ -42,7 +42,7 @@ Current version: 0.2.4.dev (as specified in [pyproject.toml](mdc:pyproject.toml)
 ### Agent Implementations
 - **[src/agents/main.py](mdc:src/agents/main.py)**: Main FastAPI service entry point
 - **[src/agents/cli.py](mdc:src/agents/cli.py)**: Command-line interface with improved logging
-- **[config.yaml](mdc:config.yaml)**: Configuration file with enhanced logging options
+- **[config.toml](mdc:config.toml)**: Configuration file with enhanced logging options
 - **[requirements.txt](mdc:requirements.txt)**: Project dependencies
 - **[src/agents/agent.py](mdc:src/agents/agent.py)**: Base agent implementation (ReAct paradigm)
 - **[src/agents/codact_agent.py](mdc:src/agents/codact_agent.py)**: CodeAct agent implementation
@@ -70,7 +70,7 @@ Current version: 0.2.4.dev (as specified in [pyproject.toml](mdc:pyproject.toml)
    - FastAPI service (`src/agents/main.py`)
 
 4. **Configuration**:
-   - [config.yaml](mdc:config.yaml): Main configuration file
+   - [config.toml](mdc:config.toml): Main configuration file
    - [config_loader.py](mdc:src/agents/config_loader.py): Configuration loading utilities
    - [prompt_templates/](mdc:src/agents/prompt_templates): Modular prompt template system
    - API keys and sensitive data in `.env` (not committed to the repository)
@@ -101,7 +101,7 @@ Current version: 0.2.4.dev (as specified in [pyproject.toml](mdc:pyproject.toml)
 
 5. **Streaming Capability** (⚠️ Not Recommended):
    - Current implementation has stability issues
-   - Set `enable_streaming: false` in config.yaml
+   - Set `enable_streaming: false` in config.toml
    - Will be improved in future releases
 
 6. **Periodic Planning**:

--- a/.env.example
+++ b/.env.example
@@ -16,4 +16,4 @@ JINA_API_KEY="your-jina-api-key"
 WOLFRAM_ALPHA_APP_ID="your-wolfram-alpha-app-id"
 
 # Note: Other configurations like model IDs, agent parameters (max_steps, etc.)
-# should now be managed in your config.yaml file (copied from config.yaml.template). 
+# should now be managed in your config.toml file (copied from config.toml.template). 

--- a/README_Zh.md
+++ b/README_Zh.md
@@ -30,7 +30,7 @@ DeepSearchAgent 项目是一个基于 ReAct（Reasoning + Acting）推理行动�
 ## 2. ✨ 特性 | Features
 
 - 👻 **深度搜索任务能力**：通过多步搜索、阅读和推理过程，处理网络内容以回答复杂问题
-- 🧑‍💻 **DeepSearch 专员**：同时支持 CodeAct（Python代码执行）模式 & 用于实验对照的 ReAct（工具调用）模式，可通过 `config.yaml` 配置相关 Agent Run time , 语言模型 和各种工具的配置参数
+- **DeepSearch 专员**：同时支持 CodeAct（Python 代码执行）模式与 ReAct（工具调用）模式，可在 `config.toml`（`src/core/config/settings.py`）中配置 Agent 运行时、语言模型和工具参数。
 - 🪄 **可扩展工具箱**：内置网络搜索、内容获取、文本处理、语义排序和计算功能的工具集
 - 🔍 **文本嵌入与重排序**：使用 Jina AI 嵌入和重排序模型处理 URL Web 多模态内容
 - 🧠 **周期性规划更新**: 在执行过程中实施战略性重评以优化搜索路径
@@ -142,7 +142,7 @@ DeepSearchAgent 项目是一个基于 ReAct（Reasoning + Acting）推理行动�
 确保您已安装 CLI 依赖项 (参见 安装与配置 第 4 步)。
 
 ```bash
-# 运行 CLI（交互模式，使用 config.yaml 中的设置）
+# 运行 CLI（交互模式，使用 config.toml 中的设置）
 make cli
 # 或直接使用:
 uv run python -m src.agents.cli
@@ -155,18 +155,18 @@ CLI 参数将覆盖 `config.toml` 中定义的设置。
 确保您已安装核心依赖项 (参见 安装与配置 第 4 步)。
 
 ```bash
-# 启动主 API 服务器（使用 config.yaml 中的 host/port，例如 http://0.0.0.0:8000）
+# 启动主 API 服务器（使用 config.toml 中的 host/port，例如 http://0.0.0.0:8000）
 make run
 # 或直接使用:
 uv run -- uvicorn src.agents.main:app --reload
-# 注意：--host 和 --port 现在通过 main.py 从 config.yaml 获取
+# 注意：--host 和 --port 现在通过 main.py 从 config.toml 获取
 # 使用 LOG_LEVEL 环境变量设置日志级别（例如 LOG_LEVEL=debug make run）
 ```
 
 **API 端点**：
 
 * `POST /run_react_agent`：运行 React 智能体。
-* `POST /run_deepsearch_agent`：运行由 `config.yaml` 中 `service.deepsearch_agent_mode`（或 `DEEPSEARCH_AGENT_MODE` 环境变量）配置的智能体。
+* `POST /run_deepsearch_agent`：运行由 `config.toml` 中 `service.deepsearch_agent_mode`（或 `DEEPSEARCH_AGENT_MODE` 环境变量）配置的智能体。
 * `GET /`：API 信息和健康检查。
 
 向配置的深度搜索端点发送 API 请求示例：
@@ -229,7 +229,7 @@ flowchart TB
         direction TB
         CoreAgents{{"Core Agents
 (Handles Mode Selection)"}}
-        ConfigLoader["Config Loader (yaml, .env)"]
+        ConfigLoader["Config Loader (toml, .env)"]
         StreamingSupport["Streaming Support"]
         subgraph Agents["Agent Logic"]
             direction LR


### PR DESCRIPTION
## Summary
- update docs to reference `config.toml` instead of the old `config.yaml`
- note new `settings.py` config loader
- adjust mermaid diagrams to show TOML config

## Testing
- `make test` *(fails: could not download build dependency)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 所有文档中的配置文件格式由 config.yaml 更新为 config.toml，包括使用说明、配置示例和架构图。
  - README.md 纠正了 CLI 路径、工具目录路径，并新增 GaiaUI Web 界面及其在架构图中的展示。
  - 术语“ToolCollection”统一更名为“Toolbox”，并修正版本号显示。
  - .env.example 文件中的相关说明同步为 config.toml。
  - 中文文档（README_Zh.md）同步进行了上述更新和路径修正。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->