### PR TITLE
docs: Add DeepWiki documentation badge to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Build with 💖 for Humanity with AI
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![version](https://img.shields.io/badge/version-v0.2.8-blue.svg)](https://github.com/DeepSearch-AgentTeam/DeepSearchAgent/releases/tag/v0.2.8)
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/lwyBZss8924d/DeepSearchAgents)
+
 </h2>
 
 > **Come From Open Source, This is the Way**

--- a/README_Zh.md
+++ b/README_Zh.md
@@ -18,6 +18,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![version](https://img.shields.io/badge/version-v0.2.8-blue.svg)](https://github.com/DeepSearch-AgentTeam/DeepSearchAgent/releases/tag/v0.2.8)
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/lwyBZss8924d/DeepSearchAgents)
+
 </h2>
 
 > 自开源 正是此道

--- a/dev-docs/commits/en-commit-message-2025-05-31-01.md
+++ b/dev-docs/commits/en-commit-message-2025-05-31-01.md
@@ -1,0 +1,26 @@
+# Add DeepWiki Documentation Badge to README Files
+
+## Summary
+Added DeepWiki documentation badge to both English and Chinese README files to provide users with interactive documentation access.
+
+## Changes Made
+- **README.md**: Added DeepWiki badge linking to project documentation
+- **README_Zh.md**: Added DeepWiki badge linking to project documentation  
+
+## Badge Details
+```markdown
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/lwyBZss8924d/DeepSearchAgents)
+```
+
+## Purpose
+DeepWiki provides up-to-date README documentation that users can interact with conversationally. This badge helps both human developers and AI developers easily find and access comprehensive documentation for the DeepSearchAgents project.
+
+## Technical Impact
+- Enhanced developer experience with interactive documentation access
+- Improved project discoverability and onboarding
+- Consistent documentation links across both language versions
+- No breaking changes to existing functionality
+
+## Related Links
+- DeepWiki Documentation: https://deepwiki.com/lwyBZss8924d/DeepSearchAgents
+- Project Repository: https://github.com/lwyBZss8924d/DeepSearchAgents

--- a/tests/test_case_codact.md
+++ b/tests/test_case_codact.md
@@ -31,3 +31,9 @@ Hello! Please search about [Executable Code Actions Elicit Better LLM Agents](ht
 ```bash
 Hello! Please Web-Search about 1. Open AI —— "[Codex] Software engineering Agent `chatgpt.com/codex`" New Product info (https://platform.openai.com/docs/codex) 2. Use Zh(中文) summary AI Agent Report for me. --- Current time: {{ CURRENT_TIME: 2025-05-16 }}
 ```
+
+===
+
+```bash
+Hi! Please Web Search latest news and twitter(x.com)Trending Top tweets about the deepseek-r1 latest releases version(deepseek-r1-0528) LLM update news and new version multiple-Benchmark(Platforms e.g. coding / Math reasoning / Computer Use / long context comprehension/etc.). Get all you need deep-search info for analysis. End of research job summary output with a fulltable report with MUST use Zh(中文) for me --- CURRENT_TIME: {{ CURRENT_TIME: 2025-05-29 }} ---
+```


### PR DESCRIPTION
Added DeepWiki documentation badge to both English and Chinese README files. Badge provides interactive documentation access via https://deepwiki.com/lwyBZss8924d/DeepSearchAgents. Enhances developer onboarding and project discoverability with no breaking changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
  - 在英文和中文 README 文件头部新增了“Ask DeepWiki”徽章，便于用户快速访问 DeepWiki 相关页面。
- **测试**
  - 新增了关于 deepseek-r1 最新版本（0528）在多平台的新闻与基准测试分析的测试用例，结果要求以中文表格形式输出。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->